### PR TITLE
shovel: create public schema if not exists

### DIFF
--- a/shovel/schema.sql
+++ b/shovel/schema.sql
@@ -1,3 +1,4 @@
+create schema if not exists public;
 create schema if not exists shovel;
 
 create table if not exists shovel.integrations (


### PR DESCRIPTION
I dropped the `public` schema when trying to reset shovel and it wouldn't start up until the schema exists. This line should allow shovel to create it if it doesn't exist.